### PR TITLE
Update build.jl for supporting windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,7 +17,8 @@ end
 
 GMSH_FOUND = false
 if gmsh_root != nothing
-  gmsh_bin = joinpath(gmsh_root,"bin","gmsh")
+  gmsh_bin = (Sys.iswindows() ? joinpath(gmsh_root,"bin","gmsh.exe") : 
+              joinpath(gmsh_root,"bin","gmsh"))
   if isfile(gmsh_bin)
     GMSH_FOUND = true
     @info "gmsh binary found in $gmsh_bin"


### PR DESCRIPTION
Fixed gmsh_bin path to comply with with windows (gmsh.exe) -> build works now on windows 10


Potential fix for issue #36 