### PR TITLE
Small bug in naming that breaks with latest version of Gridap.jl

### DIFF
--- a/src/GmshDiscreteModels.jl
+++ b/src/GmshDiscreteModels.jl
@@ -790,7 +790,7 @@ function _find_gface_to_face(
 
   ngfaces = length(gface_to_nodes_ptrs) - 1
   gface_to_face = fill(T(UNSET),ngfaces)
-  n = max_cells_arround_vertex(node_to_faces_ptrs)
+  n = max_cells_around_vertex(node_to_faces_ptrs)
   faces_around = fill(UNSET,n)
   faces_around_scratch = fill(UNSET,n)
 

--- a/src/GridapGmsh.jl
+++ b/src/GridapGmsh.jl
@@ -9,7 +9,7 @@ using Gridap.TensorValues
 using Gridap.Fields
 using Gridap.ReferenceFEs
 using Gridap.Geometry
-using Gridap.Geometry: max_cells_arround_vertex
+using Gridap.Geometry: max_cells_around_vertex
 using Gridap.Geometry: _fill_cells_around_scratch!
 using Gridap.Geometry: _set_intersection!
 using Gridap.Geometry: _generate_cell_to_vertices_from_grid


### PR DESCRIPTION
I found that these two instances of

`max_cells_arround_vertex`

were breaking the precompile of `GridapGmsh.jl`